### PR TITLE
Improve concurrency debugging with queue and node logs

### DIFF
--- a/include/core/queue.h
+++ b/include/core/queue.h
@@ -16,17 +16,23 @@ public:
             std::lock_guard<std::mutex> lk(m_);
             q_.push_back(std::move(v));
         }
+        LOG_INFO() << "BlockingQueue push exit";
         cv_.notify_one();
     }
 
     std::optional<T> popBlocking(std::atomic_bool& stop_flag)
     {
+        LOG_INFO() << "BlockingQueue pop enter";
         std::unique_lock<std::mutex> lk(m_);
         cv_.wait(lk, [&] { return stop_flag || !q_.empty(); });
         if (stop_flag && q_.empty())
+        {
+            LOG_INFO() << "BlockingQueue pop stop";
             return std::nullopt;
+        }
         T v = std::move(q_.front());
         q_.pop_front();
+        LOG_INFO() << "BlockingQueue pop exit";
         return v;
     }
 

--- a/include/graph/inode.h
+++ b/include/graph/inode.h
@@ -69,7 +69,9 @@ namespace mc
                 if (!opt.has_value())
                     break;
                 Buffer b = std::move(opt.value());
+                LOG_INFO() << "[" << name() << "] dequeued buffer: req=" << b.request_id << " frame=" << b.frame_id;
                 process(b);
+                LOG_INFO() << "[" << name() << "] buffer processed";
             }
         }
 


### PR DESCRIPTION
## Summary
- add detailed push/pop logging to `BlockingQueue`
- log buffer dequeue and processing events in `INode` run loop

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/demo` *(hangs; manual interrupt after capturing logs)*

------
https://chatgpt.com/codex/tasks/task_e_68bc094945388322aa751082250df019