### PR TITLE
Fix blocking queue stop semantics and cleanup node notifications

### DIFF
--- a/include/core/queue.h
+++ b/include/core/queue.h
@@ -3,6 +3,7 @@
 #include <condition_variable>
 #include <deque>
 #include <optional>
+#include <atomic>
 #include "common/log.h"
 
 template <typename T>
@@ -16,17 +17,23 @@ public:
             std::lock_guard<std::mutex> lk(m_);
             q_.push_back(std::move(v));
         }
+        LOG_INFO() << "BlockingQueue push exit";
         cv_.notify_one();
     }
 
-    std::optional<T> popBlocking(std::atomic_bool& stop_flag)
+    std::optional<T> popBlocking(std::atomic_bool& running_flag)
     {
+        LOG_INFO() << "BlockingQueue pop enter";
         std::unique_lock<std::mutex> lk(m_);
-        cv_.wait(lk, [&] { return stop_flag || !q_.empty(); });
-        if (stop_flag && q_.empty())
+        cv_.wait(lk, [&] { return !running_flag || !q_.empty(); });
+        if (!running_flag && q_.empty())
+        {
+            LOG_INFO() << "BlockingQueue pop stop";
             return std::nullopt;
+        }
         T v = std::move(q_.front());
         q_.pop_front();
+        LOG_INFO() << "BlockingQueue pop exit";
         return v;
     }
 
@@ -34,6 +41,11 @@ public:
     {
         std::lock_guard<std::mutex> lk(m_);
         q_.clear();
+    }
+
+    void notify_all()
+    {
+        cv_.notify_all();
     }
 
 private:

--- a/include/graph/inode.h
+++ b/include/graph/inode.h
@@ -8,7 +8,6 @@
 #include <vector>
 #include <memory>
 #include <string>
-#include <condition_variable>
 #include "common/log.h"
 
 namespace mc
@@ -51,7 +50,7 @@ namespace mc
         virtual void stop()
         {
             running_ = false;
-            cv_.notify_all();
+            inq_.notify_all();
             if (th_.joinable())
                 th_.join();
         }
@@ -69,7 +68,9 @@ namespace mc
                 if (!opt.has_value())
                     break;
                 Buffer b = std::move(opt.value());
+                LOG_INFO() << "[" << name() << "] dequeued buffer: req=" << b.request_id << " frame=" << b.frame_id;
                 process(b);
+                LOG_INFO() << "[" << name() << "] buffer processed";
             }
         }
 
@@ -85,7 +86,6 @@ namespace mc
         {
             LOG_INFO() << "[" << name_ << "] enqueue buffer: req=" << b.request_id << " frame=" << b.frame_id;
             inq_.push(std::move(b));
-            cv_.notify_one();
         }
 
         std::shared_ptr<PipelineBus> bus() const { return bus_; }
@@ -97,7 +97,6 @@ namespace mc
         std::thread th_;
         std::atomic<bool> running_{false};
         BlockingQueue<Buffer> inq_;
-        std::condition_variable cv_;
     };
 
 }  // namespace mc


### PR DESCRIPTION
## Summary
- wait for data or stop in `BlockingQueue::popBlocking` and expose `notify_all` to wake consumers
- remove redundant condition variable in `INode` and signal queue directly on shutdown

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `timeout 5s ./build/demo`

------
https://chatgpt.com/codex/tasks/task_e_68bc094945388322aa751082250df019